### PR TITLE
Switched to using indices instead of test functions

### DIFF
--- a/pytest_sherlock/binary_tree_search.py
+++ b/pytest_sherlock/binary_tree_search.py
@@ -38,6 +38,27 @@ class Node(object):
 
 
 def draw_tree(node):
+    r"""
+    The function draws schema of binary tree
+
+    >>> tree = make_tee((0, 7))
+    >>> draw_tree(tree)
+              ____________________(0, 7)_____________________
+             /                                               \
+        __(0, 3)_________                         ________(3, 7)_________
+       /                 \                       /                       \
+    (0, 1)          __(1, 3)___             __(3, 5)___             __(5, 7)___
+                   /           \           /           \           /           \
+                (1, 2)      (2, 3)      (3, 4)      (4, 5)      (5, 6)      (6, 7)
+
+    Parameters
+    ----------
+    node: Node
+
+    Returns
+    -------
+    None
+    """
     def _left_shift_lines(lines, width):
         return [line + width * " " for line in lines]
 

--- a/pytest_sherlock/binary_tree_search.py
+++ b/pytest_sherlock/binary_tree_search.py
@@ -98,9 +98,8 @@ def draw_tree(node):
             left += [l_width * " "] * (r_height - l_height)
         elif r_height < l_height:
             right += [r_width * " "] * (l_height - r_height)
-        zipped_lines = zip(left, right)
         lines = [first_line, second_line] + [
-            a + line_width * " " + b for a, b in zipped_lines
+            a + line_width * " " + b for a, b in zip(left, right)
         ]
         return (
             lines,
@@ -110,8 +109,7 @@ def draw_tree(node):
         )
 
     all_lines, _, _, _ = _count_lines(node)
-    for line in all_lines:
-        print(line)
+    print("\n".join(all_lines))
 
 
 def make_tee(items):

--- a/pytest_sherlock/binary_tree_search.py
+++ b/pytest_sherlock/binary_tree_search.py
@@ -1,46 +1,175 @@
 class Node(object):
-    def __init__(self, items):
-        self.items = items
-        self.left = None
-        self.right = None
+    def __init__(self, items, left=None, right=None):
+        self.items = self.validate(items)
+        self.left = left
+        self.right = right
+
+    def __str__(self):
+        return str(self.items)
+
+    def __repr__(self):
+        return "<Node {}>".format(self.items)
+
+    @staticmethod
+    def validate(items):
+        if not isinstance(items, tuple):
+            raise RuntimeError(
+                "Must be tuple with indices, (start, end): {}".format(items)
+            )
+        if len(items) != 2:
+            raise RuntimeError(
+                "Must contain (start, end) indices of tests: {}".format(items)
+            )
+
+        start, end = items
+        if not isinstance(start, int) or not isinstance(end, int):
+            raise RuntimeError("Indices must be integer: {}".format(items))
+        if start < 0:
+            raise RuntimeError(
+                "Invalid start index must be started from 0 or greater: {}".format(
+                    items
+                )
+            )
+        if start >= end:
+            raise RuntimeError(
+                "Invalid end index must be greater than start: {}".format(items)
+            )
+        return items
 
 
-class Root(object):
-    def __init__(self):
-        self.root = None
+def draw_tree(node):
+    def _count_lines(current_node):
+        """Returns list of strings, width, height, and horizontal coordinate of the root."""
+        line = str(current_node)
+        line_width = len(line)
+        line_middle = line_width // 2
+        line_height = 1
 
-    def insert(self, items):
-        if self.root is not None or items is None:
-            return self.root
-        self.root = Node(items)
-        return self._insert(items, self.root)
+        # No child.
+        if current_node.right is None and current_node.left is None:
+            return [line], line_width, line_height, line_middle
 
-    def _insert(self, items, current_root):
-        mid = len(items) // 2
-        if not items or mid == 0:
+        # Only left child.
+        if current_node.right is None:
+            lines, width, height, middle = _count_lines(current_node.left)
+            first_line = (middle + 1) * " " + (width - middle - 1) * "_" + line
+            second_line = middle * " " + "/" + (width - middle - 1 + line_width) * " "
+            shifted_lines = [line + line_width * " " for line in lines]
+            return (
+                [first_line, second_line] + shifted_lines,
+                width + line_width,
+                height + 2,
+                width + line_middle,
+            )
+
+        # Only right child.
+        if current_node.left is None:
+            lines, width, height, middle = _count_lines(current_node.right)
+            first_line = line + middle * "_" + (width - middle) * " "
+            second_line = (
+                (line_width + middle) * " " + "\\" + (width - middle - 1) * " "
+            )
+            shifted_lines = [line_width * " " + line for line in lines]
+            return (
+                [first_line, second_line] + shifted_lines,
+                width + line_width,
+                height + 2,
+                line_middle,
+            )
+
+        # Two children.
+        left, l_width, l_height, l_middle = _count_lines(current_node.left)
+        right, r_width, r_height, r_middle = _count_lines(current_node.right)
+        first_line = (
+            (l_middle + 1) * " "
+            + (l_width - l_middle - 1) * "_"
+            + line
+            + r_middle * "_"
+            + (r_width - r_middle) * " "
+        )
+        second_line = (
+            l_middle * " "
+            + "/"
+            + (l_width - l_middle - 1 + line_width + r_middle) * " "
+            + "\\"
+            + (r_width - r_middle - 1) * " "
+        )
+        if l_height < r_height:
+            left += [l_width * " "] * (r_height - l_height)
+        elif r_height < l_height:
+            right += [r_width * " "] * (l_height - r_height)
+        zipped_lines = zip(left, right)
+        lines = [first_line, second_line] + [
+            a + line_width * " " + b for a, b in zipped_lines
+        ]
+        return (
+            lines,
+            l_width + r_width + line_width,
+            max(l_height, r_height) + 2,
+            l_width + line_width // 2,
+        )
+
+    all_lines, _, _, _ = _count_lines(node)
+    for line in all_lines:
+        print(line)
+
+
+def make_tee(items):
+    """
+    Parameters
+    ----------
+    items: tuple[int, int]
+        (0, 21) - (start, end) indices of tests
+
+    Returns
+    -------
+    Node
+        Root node of tree
+    """
+
+    def _insert(items, current_root):
+        """
+        Parameters
+        ----------
+        items: tuple[int, int]
+            (0, 21)
+        current_root: Node
+
+        Returns
+        -------
+        None
+        """
+        start, end = items
+        if start >= end - 1:
             return
 
-        left = items[:mid]
-        if left:
-            current_root.left = Node(left)
-            self._insert(left, current_root.left)
+        middle = start + (end - start) // 2
+        if start < middle:
+            left_range = (start, middle)
+            current_root.left = Node(left_range)
+            _insert(left_range, current_root.left)
 
-        right = items[mid:]
-        if right:
-            current_root.right = Node(right)
-            self._insert(right, current_root.right)
+        if middle < end:
+            right_range = (middle, end)
+            current_root.right = Node(right_range)
+            _insert(right_range, current_root.right)
 
-    def _length(self, node):
-        if node is None:
-            return -1
-        left = self._length(node.left)
-        right = self._length(node.right)
-        return max([left, right]) + 1
+    root = Node(items)
+    _insert(items, root)
+    return root
 
-    def length(self):
-        if self.root is None:
+
+def length(node, func=max):
+    def count_length(current_node):
+        if current_node is None:
             return 0
-        return self._length(self.root)
 
-    def __len__(self):
-        return self.length()
+        left = count_length(current_node.left)
+        right = count_length(current_node.right)
+        return func([left, right]) + 1
+
+    if node is None:
+        return 0
+
+    increment = 0 if func is max else -1  # exclude root
+    return count_length(node) + increment

--- a/pytest_sherlock/binary_tree_search.py
+++ b/pytest_sherlock/binary_tree_search.py
@@ -59,6 +59,7 @@ def draw_tree(node):
     -------
     None
     """
+
     def _left_shift_lines(lines, width):
         return [line + width * " " for line in lines]
 
@@ -67,31 +68,25 @@ def draw_tree(node):
 
     def _build_left_line(middle, width):
         # '       ______'
-        template = "{0:>{space_width}}{0:_>{current_value_width}}"
+        template = "{0:>{space_width}}{0:_>{line_width}}"
         return template.format(
             "", space_width=middle + 1, line_width=width - middle - 1
         )
 
     def _build_right_line(middle, width):
         # '______       '
-        template = "{0:_>{current_value_width}}{0:>{space_width}}"
-        return template.format(
-            "", space_width=width - middle, line_width=middle
-        )
+        template = "{0:_>{line_width}}{0:>{space_width}}"
+        return template.format("", space_width=width - middle, line_width=middle)
 
     def _build_left_arrows(middle, width):
         # '      /      '
         template = "{0:>{left_width}}/{0:<{right_width}}"
-        return template.format(
-            "", left_width=middle, right_width=width - middle - 1
-        )
+        return template.format("", left_width=middle, right_width=width - middle - 1)
 
     def _build_right_arrows(middle, width):
         # '      \      '
         template = "{0:>{left_width}}\\{0:<{right_width}}"
-        return template.format(
-            "", left_width=middle, right_width=width - middle - 1
-        )
+        return template.format("", left_width=middle, right_width=width - middle - 1)
 
     def _count_lines(current_node):
         """
@@ -157,7 +152,9 @@ def draw_tree(node):
             left += [l_width * " "] * (r_height - l_height)
         elif r_height < l_height:
             right += [r_width * " "] * (l_height - r_height)
-        previous_lines = [a + current_value_width * " " + b for a, b in zip(left, right)]
+        previous_lines = [
+            a + current_value_width * " " + b for a, b in zip(left, right)
+        ]
         return (
             [value_line, arrows_line] + previous_lines,
             l_width + r_width + current_value_width,

--- a/tests/pytest_sherlock/test_binary_tree_search.py
+++ b/tests/pytest_sherlock/test_binary_tree_search.py
@@ -1,84 +1,140 @@
 import pytest
 
-from pytest_sherlock.binary_tree_search import Node, Root
-
-
-@pytest.fixture()
-def root():
-    return Root()
+from pytest_sherlock.binary_tree_search import Node, draw_tree, length, make_tee
 
 
 def test_create_node_with_default_params():
-    data = range(3)
-    node = Node(data)
-    assert node.items == data
+    tests_range = (0, 3)
+    node = Node(tests_range)
+    assert node.items == tests_range
     assert node.left is None and node.right is None
 
 
 def test_modify_node_prams():
-    data = range(3)
-    node = Node(data)
-    mid = len(data) // 2
-    node.left = Node(data[:mid])
-    node.right = Node(data[mid:])
-    assert node.items == data
+    tests_range = (0, 3)
+    node = Node(tests_range, Node((0, 1)), Node((1, 3)))
+    assert node.items == tests_range
     assert isinstance(node.left, Node) and isinstance(node.right, Node)
 
 
-def test_create_root(root):
-    assert root.root is None
+def test_make_tree_with_even_data():
+    """
+    Example of tree:
+              ________(0, 4)_________
+             /                       \
+        __(0, 2)___             __(2, 4)___
+       /           \           /           \
+    (0, 1)      (1, 2)      (2, 3)      (3, 4)
+    """
+    tests_range = (0, 4)
+    root = make_tee(tests_range)
+    assert isinstance(root, Node)
+    assert root.items == tests_range
+
+    assert isinstance(root.left, Node)
+    assert root.left.items == (0, 2)
+
+    assert root.left.left.items == (0, 1)
+    assert root.left.left.left is None
+    assert root.left.left.right is None
+    assert isinstance(root.left.right, Node)
+    assert root.left.right.items == (1, 2)
+    assert root.left.right.left is None
+    assert root.left.right.right is None
+
+    assert isinstance(root.right, Node)
+    assert root.right.items == (2, 4)
+
+    assert isinstance(root.right.right, Node)
+    assert root.right.left.items == (2, 3)
+    assert root.right.left.left is None
+    assert root.right.left.right is None
+    assert isinstance(root.right.right, Node)
+    assert root.right.right.items == (3, 4)
+    assert root.right.right.left is None
+    assert root.right.right.right is None
 
 
-def test_root_insert_even_data(root):
-    data = range(4)
-    root.insert(data)
-    assert isinstance(root.root, Node)
-    assert root.root.items == data
+def test_make_tree_with_not_even_data():
+    """
+    Example of tree:
+              ________(0, 5)_________
+             /                       \
+        __(0, 2)___             __(2, 5)_________
+       /           \           /                 \
+    (0, 1)      (1, 2)      (2, 3)          __(3, 5)___
+                                           /           \
+                                        (3, 4)      (4, 5)
+    """
+    tests_range = (0, 5)
+    root = make_tee(tests_range)
+    assert isinstance(root, Node)
+    assert root.items == tests_range
 
-    assert isinstance(root.root.left, Node)
-    assert root.root.left.items == data[:2]
-    assert isinstance(root.root.left.left, Node)
-    assert root.root.left.left.items == data[:1]
-    assert root.root.left.left.left is None
+    assert isinstance(root.left, Node)
+    assert root.left.items == (0, 2)
 
-    assert isinstance(root.root.right, Node)
-    assert root.root.right.items == data[-2:]
-    assert isinstance(root.root.right.right, Node)
-    assert root.root.right.right.items == data[-1:]
-    assert root.root.right.right.right is None
+    assert root.left.left.items == (0, 1)
+    assert root.left.left.left is None
+    assert root.left.left.right is None
+    assert isinstance(root.left.right, Node)
+    assert root.left.right.items == (1, 2)
+    assert root.left.right.left is None
+    assert root.left.right.right is None
 
+    assert isinstance(root.right, Node)
+    assert root.right.items == (2, 5)
 
-def test_root_insert_not_even_data(root):
-    data = range(5)
-    root.insert(data)
-    assert isinstance(root.root, Node)
-    assert root.root.items == data
-
-    assert isinstance(root.root.left, Node)
-    assert root.root.left.items == data[:2]
-    assert isinstance(root.root.left.left, Node)
-    assert root.root.left.left.items == data[:1]
-    assert root.root.left.left.left is None
-
-    assert isinstance(root.root.right, Node)
-    assert root.root.right.items == data[-3:]
-    assert isinstance(root.root.right.right, Node)
-    assert root.root.right.right.items == data[-2:]
-    assert isinstance(root.root.right.right.right, Node)
-    assert root.root.right.right.right.items == data[-1:]
-    assert root.root.right.right.right.right is None
-
-
-def test_root_insert_without_data(root):
-    root.insert(None)
-    assert root.root is None
+    assert isinstance(root.right.right, Node)
+    assert root.right.left.items == (2, 3)
+    assert root.right.left.left is None
+    assert root.right.left.right is None
+    assert isinstance(root.right.right, Node)
+    assert root.right.right.items == (3, 5)
+    assert root.right.right.left.items == (3, 4)
+    assert root.right.right.right.items == (4, 5)
 
 
-def test_root_length(root):
-    root.insert(range(4))
-    assert len(root) == 2
+@pytest.mark.parametrize(
+    "data",
+    (
+        pytest.param(tuple(), id="empty"),
+        pytest.param((1, 4, 7), id="wrong_amount_of_indices"),
+        pytest.param((-1, 3), id="invalid_start_index"),
+        pytest.param((3, 1), id="invalid_end_index"),
+        pytest.param((0, "2"), id="invalid_end_type"),
+    ),
+)
+def test_make_tree_with_invalid_data(data):
+    with pytest.raises(RuntimeError):
+        make_tee(data)
 
 
-def test_not_even_root_length(root):
-    root.insert(range(5))
-    assert len(root) == 3
+@pytest.mark.parametrize(
+    "data, func, exp_result",
+    (
+        pytest.param((0, 4), max, 3, id="max_of_even"),
+        pytest.param((0, 4), min, 2, id="min_of_even"),
+        pytest.param((0, 5), max, 4, id="max_of_not_even"),
+        pytest.param((0, 5), min, 2, id="min_of_not_even"),
+    ),
+)
+def test_count_length(data, func, exp_result):
+    """
+    Example of tree:
+              ________(0, 4)_________
+             /                       \
+        __(0, 2)___             __(2, 4)___
+       /           \           /           \
+    (0, 1)      (1, 2)      (2, 3)      (3, 4)
+
+              ________(0, 5)_________
+             /                       \
+        __(0, 2)___             __(2, 5)_________
+       /           \           /                 \
+    (0, 1)      (1, 2)      (2, 3)          __(3, 5)___
+                                           /           \
+                                        (3, 4)      (4, 5)
+
+    """
+    assert length(make_tee(data), func) == exp_result

--- a/tests/pytest_sherlock/test_binary_tree_search.py
+++ b/tests/pytest_sherlock/test_binary_tree_search.py
@@ -138,3 +138,17 @@ def test_count_length(data, func, exp_result):
 
     """
     assert length(make_tee(data), func) == exp_result
+
+
+def test_draw_tree(capsys):
+    exp_result = (
+        "          ________(0, 5)_________                     \n"
+        "         /                       \\                    \n"
+        "    __(0, 2)___             __(2, 5)_________         \n"
+        "   /           \\           /                 \\        \n"
+        "(0, 1)      (1, 2)      (2, 3)          __(3, 5)___   \n"
+        "                                       /           \\  \n"
+        "                                    (3, 4)      (4, 5)\n"
+    )
+    draw_tree(make_tee((0, 5)))
+    assert capsys.readouterr().out == exp_result


### PR DESCRIPTION
Done:
- added validation while making binary tree
- added more verbose errors in case "--flaky-test" was not found in a collection
- switched to using indices of collection instead of making the number of collections in BTS
- added `pytest_sherlock.binary_tree_search.draw_tree` for easy debugging/understanding how BTS looks like
   ```
   Collection of tests:
        0, 'tests/test_tree.py::test_tree'
        1, 'tests/test_one.py::test_one'
        2, 'tests/test_two.py::test_two'
        3, 'tests/test_four.py::test_four'

    Example of binary tree:
              ________(0, 4)_________
             /                       \
        __(0, 2)___             __(2, 4)___
       /           \           /           \
    (0, 1)      (1, 2)      (2, 3)      (3, 4)
   ```