### PR TITLE
[#16] Fixed wrong type of `SetupState.stack`

### DIFF
--- a/pytest_sherlock/plugin.py
+++ b/pytest_sherlock/plugin.py
@@ -3,6 +3,9 @@ from __future__ import absolute_import
 from pytest_sherlock.sherlock import Sherlock
 
 
+PLUGIN_NAME = "pytest_sherlock.plugin"
+
+
 def pytest_addoption(parser):
     group = parser.getgroup("sherlock", "Try to find coupled tests")
     group.addoption(
@@ -25,8 +28,10 @@ def pytest_configure(config):
     if not config.getoption("--flaky-test"):
         return
 
-    config.sherlock = Sherlock(config)
-    config.pluginmanager.register(config.sherlock)
+    plugin = config.pluginmanager.get_plugin(PLUGIN_NAME)
+    if not plugin:
+        config.sherlock = Sherlock(config)
+        config.pluginmanager.register(config.sherlock, name=PLUGIN_NAME)
 
 
 def pytest_report_teststatus(report):

--- a/pytest_sherlock/plugin.py
+++ b/pytest_sherlock/plugin.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from pytest_sherlock.sherlock import Sherlock
 
-
 PLUGIN_NAME = "pytest_sherlock.plugin"
 
 

--- a/pytest_sherlock/sherlock.py
+++ b/pytest_sherlock/sherlock.py
@@ -55,15 +55,13 @@ def _remove_cached_results_from_failed_fixtures(item):
 
 def _remove_failed_setup_state_from_session(item):
     """
-    Note: remove all _prepare_exc attribute from every col in stack of _setupstate and
-    cleaning the stack itself
+    Force to call teardown for item.
     """
-    prepare_exc = "_prepare_exc"
     setup_state = getattr(item.session, "_setupstate")
-    for col in setup_state.stack:
-        if hasattr(col, prepare_exc):
-            delattr(col, prepare_exc)
-    setup_state.stack = []
+    if hasattr(setup_state, "teardown_all"):
+        setup_state.teardown_all()  # until pytest 6.2.5
+    else:
+        setup_state.teardown_exact(None)  # from pytest 7.0.0
     return True
 
 

--- a/tests/exmaple/conftest.py
+++ b/tests/exmaple/conftest.py
@@ -3,7 +3,6 @@ import os
 
 import pytest
 
-pytest_plugins = "pytest_sherlock.plugin"
 EXAMPLE_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/tests/pytest_sherlock/test_sherlock.py
+++ b/tests/pytest_sherlock/test_sherlock.py
@@ -125,7 +125,7 @@ class TestCleanupItem(object):
 
     @pytest.fixture
     def stack(self):
-        return [mock.MagicMock(_prepare_exc=1)]
+        return {}
 
     @pytest.fixture
     def called_item(self, target_item, fixtures, stack):
@@ -142,16 +142,10 @@ class TestCleanupItem(object):
             for func in funcs:
                 assert func.cached_result is None, "`cached_result` wasn't cleanup"
 
-    @staticmethod
-    def check_cleanup_stack(stack):
-        assert stack
-        for cal in stack:
-            assert not hasattr(cal, "_prepare_exc"), "_prepare_exc wasn't delete"
-
     def test_refresh_state(self, called_item, fixtures, stack):
         assert refresh_state(called_item)
         self.check_cleanup_fixtures(fixtures)
-        self.check_cleanup_stack(stack)
+        assert not stack
 
     def test_write_coupled_report_without_fixtures(self, called_item):
         coupled_tests = [


### PR DESCRIPTION
### Problem
had run locally example:
```bash
pytest tests/exmaple/test_c_delete.py tests/exmaple/test_b_modify.py tests/exmaple/test_all_read.py --flaky-test="test_read_params" -vv
```
and unexpectedly got error
```python

../../.virtualenvs/pytest-sherlock/lib/python3.10/site-packages/_pytest/runner.py:341: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../.virtualenvs/pytest-sherlock/lib/python3.10/site-packages/_pytest/runner.py:262: in <lambda>
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
../../.virtualenvs/pytest-sherlock/lib/python3.10/site-packages/pluggy/_hooks.py:433: in __call__
    return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
../../.virtualenvs/pytest-sherlock/lib/python3.10/site-packages/pluggy/_manager.py:112: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
../../.virtualenvs/pytest-sherlock/lib/python3.10/site-packages/_pytest/runner.py:157: in pytest_runtest_setup
    item.session._setupstate.setup(item)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <_pytest.runner.SetupState object at 0x105708460>, item = <Function test_read_params>

    def setup(self, item: Item) -> None:
        """Setup objects along the collector chain to the item."""
        needed_collectors = item.listchain()
    
        # If a collector fails its setup, fail its entire subtree of items.
        # The setup is not retried for each item - the same exception is used.
>       for col, (finalizers, exc) in self.stack.items():
E       AttributeError: 'list' object has no attribute 'items'

../../.virtualenvs/pytest-sherlock/lib/python3.10/site-packages/_pytest/runner.py:484: AttributeError
```

My current setup of environ was:
```bash
pytest             7.4.0
pytest-cov         2.6.0
pytest-sherlock    0.3.2.dev7     /Users/denis.korytkin/workspace/pytest-sherlock
```
#### Obviously, related to the newer version of **pytest**
##### 7.0.0
https://github.com/pytest-dev/pytest/blob/3554b833c24f541af5c7272e47cfa52b89d8138d/src/_pytest/runner.py#L471-L480

##### 4.6.11
https://github.com/pytest-dev/pytest/blob/2262734edfce27bed7839c93a9f7c42ace056a70/src/_pytest/runner.py#L281-L282

### Changes
- removed `_prepare_exc`
- use methods from `pytest` to force teardown
  - use different methods, depends on version of `pytest`
