### PR TITLE
[#16] Fixed `AttributeError`

### DIFF
--- a/pytest_sherlock/sherlock.py
+++ b/pytest_sherlock/sherlock.py
@@ -412,7 +412,10 @@ class Sherlock(object):
         elif test_report.outcome != "passed":
             test_report.outcome = "flaky"
             if self.verbose:
-                test_report.longrepr.toterminal(self.reporter._tw)
+                if hasattr(test_report.longrepr, "toterminal"):
+                    test_report.longrepr.toterminal(self.reporter._tw)
+                else:
+                    self.reporter.line(str(test_report.longrepr))
 
     @pytest.hookimpl(hookwrapper=True, trylast=True)
     def pytest_sessionfinish(self, session):


### PR DESCRIPTION
### Problem
The `pytest` has different types of `longrepr` in different cases.
- `str`
- `tuple`
- `None`
- `TerminalRepr`


https://github.com/pytest-dev/pytest/blob/556e075d23a91eb42821129a5d874ec3174e17ad/src/_pytest/runner.py#L372

```python
/python3.7/site-packages/pluggy/callers.py", line 203, in _multicall
     gen.send(outcome)
/python3.7/site-packages/pytest_sherlock/sherlock.py", line 418, in pytest_runtest_makereport
     test_report.longrepr.toterminal(self.reporter._tw)
AttributeError: 'tuple' object has no attribute 'toterminal'
```

### Changes
- Fixed `AttributeError`