### PR TITLE
[#15] upgraded linters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         run: black pytest_sherlock --check --diff
 
       - name: Pylint
-        run: pylint --py3k pytest_sherlock
+        run: pylint pytest_sherlock
 
       - name: Isort
         run: isort pytest_sherlock --check

--- a/pytest_sherlock/binary_tree_search.py
+++ b/pytest_sherlock/binary_tree_search.py
@@ -49,7 +49,7 @@ def draw_tree(node):
 
     Returns
     -------
-    None
+    str
     """
 
     def _left_shift_lines(lines, width):
@@ -155,7 +155,7 @@ def draw_tree(node):
         )
 
     all_lines, _, _, _ = _count_lines(node)
-    print("\n".join(all_lines))
+    return "\n".join(all_lines)
 
 
 def make_tee(items):

--- a/pytest_sherlock/binary_tree_search.py
+++ b/pytest_sherlock/binary_tree_search.py
@@ -8,32 +8,24 @@ class Node(object):
         return str(self.items)
 
     def __repr__(self):
-        return "<Node {}>".format(self.items)
+        return f"<Node {self.items}>"
 
     @staticmethod
     def validate(items):
         if not isinstance(items, tuple):
-            raise RuntimeError(
-                "Must be tuple with indices, (start, end): {}".format(items)
-            )
+            raise RuntimeError(f"Must be tuple with indices, (start, end): {items}")
         if len(items) != 2:
-            raise RuntimeError(
-                "Must contain (start, end) indices of tests: {}".format(items)
-            )
+            raise RuntimeError(f"Must contain (start, end) indices of tests: {items}")
 
         start, end = items
         if not isinstance(start, int) or not isinstance(end, int):
-            raise RuntimeError("Indices must be integer: {}".format(items))
+            raise RuntimeError(f"Indices must be integer: {items}")
         if start < 0:
             raise RuntimeError(
-                "Invalid start index must be started from 0 or greater: {}".format(
-                    items
-                )
+                f"Invalid start index must be started from 0 or greater: {items}"
             )
         if start >= end:
-            raise RuntimeError(
-                "Invalid end index must be greater than start: {}".format(items)
-            )
+            raise RuntimeError(f"Invalid end index must be greater than start: {items}")
         return items
 
 

--- a/pytest_sherlock/plugin.py
+++ b/pytest_sherlock/plugin.py
@@ -36,3 +36,4 @@ def pytest_configure(config):
 def pytest_report_teststatus(report):
     if report.outcome == "flaky":
         return "flaky", "F", ("FLAKY", {"yellow": True})
+    return None

--- a/pytest_sherlock/sherlock.py
+++ b/pytest_sherlock/sherlock.py
@@ -1,12 +1,17 @@
 from __future__ import absolute_import
 
 import contextlib
+from typing import List, Optional
 
 import pytest
 import six
+from _pytest.config import Config
 from _pytest.junitxml import _NodeReporter
+from _pytest.main import Session
+from _pytest.python import Function
+from _pytest.terminal import TerminalReporter
 
-from pytest_sherlock.binary_tree_search import length, make_tee
+from pytest_sherlock.binary_tree_search import draw_tree, length, make_tee
 
 
 class SherlockError(Exception):
@@ -33,7 +38,11 @@ class NotFoundError(SherlockError):
 
 def _remove_cached_results_from_failed_fixtures(item):
     """
-    Note: remove all cached_result attribute from every fixture
+    This function force to remove all cached_result attribute from every fixture
+
+    Parameters
+    ----------
+    item: Function
     """
     try:
         info = getattr(item, "_fixtureinfo")
@@ -56,6 +65,10 @@ def _remove_cached_results_from_failed_fixtures(item):
 def _remove_failed_setup_state_from_session(item):
     """
     Force to call teardown for item.
+
+    Parameters
+    ----------
+    item: Function
     """
     setup_state = getattr(item.session, "_setupstate")
     if hasattr(setup_state, "teardown_all"):
@@ -66,6 +79,11 @@ def _remove_failed_setup_state_from_session(item):
 
 
 def refresh_state(item):
+    """
+    Parameters
+    ----------
+    item: Function
+    """
     _remove_cached_results_from_failed_fixtures(item)
     _remove_failed_setup_state_from_session(item)
     return True
@@ -73,9 +91,16 @@ def refresh_state(item):
 
 def write_coupled_report(coupled_tests):
     """
-    :param list[_pytest.python.Function] coupled_tests: list of coupled tests
+    Parameters
+    ----------
+    coupled_tests: List[_pytest.python.Function]
+        list of coupled tests
+
+    Returns
+    -------
+    str
     """
-    # TODO can I get info about modified common fixtures?
+    # Can I get info about modified common fixtures?
     coupled_test_names = [t.nodeid.replace("::()::", "::") for t in coupled_tests]
     common_fixtures = set.intersection(*[set(t.fixturenames) for t in coupled_tests])
     coupled_tests = "\n".join(coupled_test_names)
@@ -119,6 +144,89 @@ def make_collection(items, binary_tree=None):
             current_node = current_node.right
 
 
+class Collection:
+    def __init__(self, collection, binary_tree, target_test_method):
+        self.collection = collection
+        self.binary_tree = binary_tree
+        self.target_test_method = target_test_method
+        self.min = length(self.binary_tree, min)
+        self.max = length(self.binary_tree, max)
+
+    @classmethod
+    def make(cls, items, target_test_method):
+        binary_tree = make_tee((0, len(items)))
+        collection = make_collection(items, binary_tree=binary_tree)
+        return cls(
+            collection=collection,
+            binary_tree=binary_tree,
+            target_test_method=target_test_method,
+        )
+
+    def send(self, is_fail: bool):
+        items = self.collection.send(is_fail)
+        if items:
+            items.append(self.target_test_method)
+            refresh_state(item=self.collection.target_test_method)
+        return items
+
+    def __next__(self):
+        items = next(self.collection)
+        if items:
+            items.append(self.target_test_method)
+        return items
+
+    def __str__(self):
+        return draw_tree(self.binary_tree)
+
+
+class Steps:
+    STEPS_KEY = "PytestSherlock/steps"
+    LAST_FAILED_KEY = "cache/lastfailed"
+
+    def __init__(self, config: Config):
+        self.config = config
+        self.steps = []
+        self.start_from_step = self.config.option.step
+
+    def add(self, items):
+        self.steps.append([item.nodeid for item in items])
+        return True
+
+    def setup_from_step(self, items):
+        """
+        Uses cache to get data about previous execution for filtering out tests only for this step.
+        Could be useful in case when global state was modified and
+        reduce step to reproduce an issue.
+
+        Parameters
+        ----------
+        items: List[_pytest.python.Function]
+
+        Returns
+        -------
+        List[_pytest.python.Function]
+        """
+        if self.start_from_step:
+            target_step = self.start_from_step - 1
+            if self.steps and len(self.steps) > target_step:
+                tests_from_step = self.steps[target_step]
+                items[:] = [item for item in items if item.nodeid in tests_from_step]
+            else:
+                # not found any steps in cache from previous execution
+                self.start_from_step = None
+        return items
+
+    def read(self):
+        pass
+
+    def store(self, last_failed_items: Optional[List[Function]] = None):
+        self.config.cache.set(self.STEPS_KEY, self.steps)
+        if last_failed_items:
+            self.config.cache.set(
+                self.LAST_FAILED_KEY, {i.nodeid: True for i in last_failed_items}
+            )
+
+
 @contextlib.contextmanager
 def log(item):
     item.ihook.pytest_runtest_logstart(nodeid=item.nodeid, location=item.location)
@@ -130,50 +238,17 @@ class Sherlock(object):
     KEY = "PytestSherlock/steps"
 
     def __init__(self, config):
-        self.config = config
-        self._steps = []
-        self.start_from_step = self.config.option.step
-        self.verbose = self.config.getvalue("verbose") >= 2
+        self.config: Config = config
+        self._steps: Steps = Steps(self.config)
         # initialize via pytest_sessionstart
-        self.reporter = None
-        self.session = None
+        self.reporter: Optional[TerminalReporter] = None
+        self.session: Optional[Session] = None
         # initialize via pytest_collection_modifyitems
-        self.collection = None
-        self.target_test_method = None
-        self._min_iterations = 0
-        self._max_iterations = 0
+        self.collection: Optional[Collection] = None
         # initialize via pytest_runtest_makereport
         self.failed_report = None
         # initialize via pytest_runtestloop
         self.last_failed = None
-
-    def add_step(self, items):
-        self._steps.append([item.nodeid for item in items])
-        return True
-
-    def setup_from_step(self, items):
-        """
-        Uses cache to get data about previous execution for filtering out tests only for this step.
-        Could be useful in case when global state was modified and
-        reduce step to reproduce an issue.
-
-        Parameters
-        ----------
-        items: list[_pytest.python.Function]
-
-        Returns
-        -------
-        list[_pytest.python.Function]
-        """
-        if self.start_from_step:
-            target_step = self.start_from_step - 1
-            if self._steps and len(self._steps) > target_step:
-                tests_from_step = self._steps[target_step]
-                items[:] = [item for item in items if item.nodeid in tests_from_step]
-            else:
-                # not found any steps in cache from previous execution
-                self.start_from_step = None
-        return items
 
     def write_step(self, step, maximum):
         """
@@ -205,7 +280,10 @@ class Sherlock(object):
         tests/exmaple/test_all_read.py::test_read_params FAILED                 [100%]
         ...
 
-        :param list[_pytest.python.Function] items: bucket of tests
+        Parameters
+        ----------
+        items: List[_pytest.python.Function]
+            bucket of tests
         """
         self.failed_report = None
         setattr(self.reporter, "_progress_nodeids_reported", set())
@@ -215,8 +293,12 @@ class Sherlock(object):
         """
         Patch reports console output and Junit result xml
         to avoid multi errors in report
-        :param _pytest.runner.TestReport failed_report:
-        :param list[_pytest.python.Function] coupled: list of coupled tests, last should be target
+
+        Parameters
+        ----------
+        failed_report: _pytest.runner.TestReport
+        coupled: List[_pytest.python.Function]
+            list of coupled tests, last should be a target
         """
         target_item = coupled[-1]
         if hasattr(failed_report.longrepr, "reprcrash"):
@@ -239,7 +321,7 @@ class Sherlock(object):
     @pytest.hookimpl(hookwrapper=True, trylast=True)
     def pytest_sessionstart(self, session):
         self.session = session
-        self._steps = self.config.cache.get(self.KEY, [])
+        self._steps.read()
         if self.reporter is None:
             self.reporter = self.config.pluginmanager.get_plugin("terminalreporter")
         yield
@@ -279,9 +361,13 @@ class Sherlock(object):
                     /   \        /    \
                  [0]    [1]    [2]    [3]
 
-        :param _pytest.main.Session session:
-        :param _pytest.config.Config config: pytest config object
-        :param List[_pytest.python.Function] items: list of item objects
+        Parameters
+        ----------
+        session: _pytest.main.Session
+        config: _pytest.config.Config
+            pytest config object
+        items: List[_pytest.python.Function]
+            list of item objects
         """
         _ = session  # to make pylint happy
         if config.getoption("--flaky-test"):
@@ -289,40 +375,44 @@ class Sherlock(object):
                 items, config.option.flaky_test.strip()
             )
             target_items = sorted(
-                self.setup_from_step(items[:idx]),
+                self._steps.setup_from_step(items[:idx]),
                 key=lambda item: (
                     len(set(item.fixturenames) & set(target_test_method.fixturenames)),
-                    item.parent.nodeid,  # TODO can we do AST or Name or Content analysis?
+                    item.parent.nodeid,  # Can we do AST or Name or Content analysis?
                 ),
                 reverse=True,
             )
             items[:] = [target_test_method]
-            self.target_test_method = target_test_method
-            binary_tree = make_tee((0, len(target_items)))
-            self._min_iterations = length(binary_tree, min)
-            self._max_iterations = length(binary_tree, max)
-            self.collection = make_collection(target_items, binary_tree=binary_tree)
+            self.collection = Collection.make(
+                target_items, target_test_method=target_test_method
+            )
         yield
 
     @pytest.hookimpl(trylast=True)
     def pytest_report_collectionfinish(self, config, startdir, items):
         """
         Write summary which minimum steps need to find guilty tests
-        :param _pytest.config.Config config: pytest config object
-        :param py._path.local.LocalPath startdir:
-        :param List[_pytest.python.Function] items: contain just target test
+        Parameters
+        ----------
+        config: _pytest.config.Config
+            pytest config object
+        startdir: py._path.local.LocalPath
+        items: List[_pytest.python.Function]
+            contain just target test
         """
         _ = config, startdir, items  # to make pylint happy
-        msg = f"Try to find coupled tests in [{self._min_iterations}-{self._max_iterations}] steps"
-        if self.start_from_step:
-            msg = f"{msg} (reproduce from {self.start_from_step} step)"
+        msg = f"Try to find coupled tests in [{self.collection.min}-{self.collection.max}] steps"
+        if self._steps.start_from_step:
+            msg = f"{msg} (reproduce from {self._steps.start_from_step} step)"
         return msg
 
     def pytest_runtestloop(self, session):
         """
         Just fork origin pytest method and reuse own `pytest_runtest_protocol` inside
         session.items always a list with the single target test
-        :param _pytest.main.Session session:
+        Parameters
+        ----------
+        session: _pytest.main.Session
         """
         if (
             session.testsfailed
@@ -336,10 +426,9 @@ class Sherlock(object):
         step = 1
         items = next(self.collection)
         while items:
-            items.append(self.target_test_method)
-            self.write_step(step, self._max_iterations)
+            self.write_step(step, self.collection.max)
             self.reset_progress(items)
-            self.add_step(items)
+            self._steps.add(items)
 
             for next_idx, item in enumerate(items, 1):
                 next_item = items[next_idx] if next_idx < len(items) else None
@@ -361,7 +450,7 @@ class Sherlock(object):
                 break
 
             step += 1
-            refresh_state(item=self.target_test_method)
+
         return True
 
     @pytest.hookimpl(hookwrapper=True, trylast=True)
@@ -370,23 +459,20 @@ class Sherlock(object):
         report = yield
         test_report = report.get_result()
         if (
-            test_report.nodeid == self.target_test_method.nodeid
+            test_report.nodeid == self.collection.target_test_method.nodeid
             and test_report.outcome != "passed"
         ):
             self.failed_report = test_report
         elif test_report.outcome != "passed":
             test_report.outcome = "flaky"
-            if self.verbose:
+            if self.config.getvalue("verbose") >= 2:
                 if hasattr(test_report.longrepr, "toterminal"):
-                    test_report.longrepr.toterminal(self.reporter._tw)
+                    test_report.longrepr.toterminal(self.config.get_terminal_writer())
                 else:
                     self.reporter.line(str(test_report.longrepr))
 
     @pytest.hookimpl(hookwrapper=True, trylast=True)
     def pytest_sessionfinish(self, session):
+        _ = session  # to make pylint happy
         yield
-        session.config.cache.set(self.KEY, self._steps)
-        if self.last_failed:
-            session.config.cache.set(
-                "cache/lastfailed", {i.nodeid: True for i in self.last_failed}
-            )
+        self._steps.store(self.last_failed)

--- a/pytest_sherlock/sherlock.py
+++ b/pytest_sherlock/sherlock.py
@@ -166,7 +166,7 @@ class Collection:
         items = self.collection.send(is_fail)
         if items:
             items.append(self.target_test_method)
-            refresh_state(item=self.collection.target_test_method)
+            refresh_state(item=self.target_test_method)
         return items
 
     def __next__(self):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,8 +7,8 @@ pytest-cov
 codecov
 coverage
 
-black
-isort
-pylint==2.7.4
+black>=23.7.0
+isort>=5.12.0
+pylint>=2.17.5
 twine>=1.15.0
 wheel>=0.34.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,8 @@ pytest-cov
 codecov
 coverage
 
-black>=23.7.0
+black==23.3.0; python_version <= "3.7"
+black>=23.7.0; python_version >= "3.8"
 isort>=5.12.0
 pylint>=2.17.5
 twine>=1.15.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,8 @@ coverage
 
 black==23.3.0; python_version <= "3.7"
 black>=23.7.0; python_version >= "3.8"
-isort>=5.12.0
+isort==5.11.5; python_version <= "3.7"
+isort>=5.12.0; python_version >= "3.8"
 pylint>=2.17.5
 twine>=1.15.0
 wheel>=0.34.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ max-line-length = 100
 ignore = _version.py
 
 [pylint.messages_control]
-disable = C0114, R0205, C0115, C0116
+disable = C0114, R0205, C0115, C0116, R0914
 
 [isort]
 profile = black

--- a/tests/pytest_sherlock/test_binary_tree_search.py
+++ b/tests/pytest_sherlock/test_binary_tree_search.py
@@ -140,7 +140,7 @@ def test_count_length(data, func, exp_result):
     assert length(make_tee(data), func) == exp_result
 
 
-def test_draw_tree(capsys):
+def test_draw_tree():
     exp_result = (
         "          ________(0, 5)_________                     \n"
         "         /                       \\                    \n"
@@ -148,7 +148,6 @@ def test_draw_tree(capsys):
         "   /           \\           /                 \\        \n"
         "(0, 1)      (1, 2)      (2, 3)          __(3, 5)___   \n"
         "                                       /           \\  \n"
-        "                                    (3, 4)      (4, 5)\n"
+        "                                    (3, 4)      (4, 5)"
     )
-    draw_tree(make_tee((0, 5)))
-    assert capsys.readouterr().out == exp_result
+    assert draw_tree(make_tee((0, 5))) == exp_result

--- a/tests/pytest_sherlock/test_sherlock.py
+++ b/tests/pytest_sherlock/test_sherlock.py
@@ -238,11 +238,9 @@ class TestSherlock(object):
 
         sherlock = Sherlock(config)
         assert sherlock.config == config
-        assert sherlock.verbose is True
         assert sherlock.collection is None
         assert sherlock.session is None
         assert sherlock.reporter is None
-        assert sherlock.target_test_method is None
         assert sherlock.failed_report is None
 
     def test_instance_after_pytest_sessionstart(self, config, session, reporter):
@@ -250,11 +248,9 @@ class TestSherlock(object):
         next(sherlock.pytest_sessionstart(session))
 
         assert sherlock.config == config
-        assert sherlock.verbose is True
         assert sherlock.collection is None
         assert sherlock.session == session
         assert sherlock.reporter == reporter
-        assert sherlock.target_test_method is None
         assert sherlock.failed_report is None
 
     @pytest.mark.parametrize("line", ("123", 12), ids=["string", "integer"])


### PR DESCRIPTION
### Problem

We still use `--py3k` flag for `pylint` but fully switched to Python3.
Need finally to get rid of this flag.


### Changes
- upgraded linters
- removed `--py3k` flag from `pylint` execution